### PR TITLE
Verilog testbench updated to support newer jtag_vpi:0-r5.

### DIFF
--- a/swervolf.core
+++ b/swervolf.core
@@ -1,6 +1,6 @@
 CAPI=2:
 
-name : ::swervolf:0.6
+name : ::swervolf:0.6.1
 
 filesets:
   core:
@@ -33,7 +33,7 @@ filesets:
 
   verilator_tb:
     files: [tb/tb.cpp : {file_type : cppSource}]
-    depend : [jtag_vpi]
+    depend : [">=::jtag_vpi:0-r5"]
   verilator_waiver: {files: [data/verilator_waiver.vlt : {file_type : vlt}]}
 
   spi_tb:


### PR DESCRIPTION
This pull request contains updates in the Verilator testbench, as needed to adopt newer **jtag_vpi:0-r5**.

The changes shall be used together with: https://github.com/fjullien/jtag_vpi/pull/7