### PR TITLE
Configure OpenOCD to utilize abstract mem. access

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ SweRVolf supports debugging both on hardware and in simulation. There are differ
 
 ### Prerequisites
 
-Install the RISC-V-specific version of OpenOCD
+Install the RISC-V-specific version of OpenOCD. (The OpenOCD code shall be no older than commit 22d771d2 from Sep 14, 2020.)
 
     git clone https://github.com/riscv/riscv-openocd
     cd riscv-openocd

--- a/data/swervolf_nexys_debug.cfg
+++ b/data/swervolf_nexys_debug.cfg
@@ -16,15 +16,26 @@ jtag newtap $_CHIPNAME cpu -irlen 6 -expected-id 0x03631093 -ignore-version
 set _TARGETNAME $_CHIPNAME.cpu
 target create $_TARGETNAME riscv -chain-position $_TARGETNAME
 
-# Memory access method 
-# (prefer System Bus Access as there is no Debug Program Buffer in SweRV EH1)
-riscv set_prefer_sba on
+# No MMU on SweRV (do not attempt virt2phys address translation)
+riscv set_enable_virt2phys off
+
+# Configure memory access method
+# Utilize "abstract access" to allow to reach SweRV's ICCM, DCCM and PIC core-local memories.
+# Note: Requires SweRV EH1 1.8+ and recent riscv-openocd (commit 22d771d20 from Sep 14, 2020, or newer).
+riscv set_mem_access abstract
+
+# Alternate memory access configuration - via "system bus"
+# Caution: ICCM, DCCM and PIC cannot be reached.
+# riscv set_mem_access sysbus
 
 # Custom numbers for RISC-V Debug JTAG registers 
 # (needed due to JTAG tunneling via Xilinx BSCAN cell)
 riscv set_ir idcode 0x9
 riscv set_ir dmi 0x22
 riscv set_ir dtmcs 0x23
+
+# Expose custom SweRV's CSR dmst (csr1988)
+riscv expose_csrs 1988
 
 # Custom event hooks to flush SweRV ICACHE prior to step/resume
 proc swerv_eh1_execute_fence {} {
@@ -37,8 +48,6 @@ $_TARGETNAME configure -event resume-start {
 }
 
 $_TARGETNAME configure -event step-start {
-    # Note: As of Q2/2020, "step-start" event is a new feature in OpenOCD.
-    # A very recent version of OpenOCD is needed (upstream commit 25efc150 or newer).
     swerv_eh1_execute_fence
 }
 

--- a/data/swervolf_sim.cfg
+++ b/data/swervolf_sim.cfg
@@ -10,9 +10,20 @@ jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x01
 set _TARGETNAME $_CHIPNAME.cpu
 target create $_TARGETNAME riscv -chain-position $_TARGETNAME
 
-# Memory access method 
-# (prefer System Bus Access as there is no Debug Program Buffer in SweRV EH1)
-riscv set_prefer_sba on
+# No MMU on SweRV (do not attempt virt2phys address translation)
+riscv set_enable_virt2phys off
+
+# Configure memory access method
+# Utilize "abstract access" to allow to reach SweRV's ICCM, DCCM and PIC core-local memories.
+# Note: Requires SweRV EH1 1.8+ and recent riscv-openocd (commit 22d771d20 from Sep 14, 2020, or newer).
+riscv set_mem_access abstract
+
+# Alternate memory access configuration - via "system bus"
+# Caution: ICCM, DCCM and PIC cannot be reached.
+# riscv set_mem_access sysbus
+
+# Expose custom SweRV's CSR dmst (csr1988)
+riscv expose_csrs 1988
 
 # Custom event hooks to flush SweRV ICACHE prior to step/resume
 proc swerv_eh1_execute_fence {} {
@@ -25,8 +36,6 @@ $_TARGETNAME configure -event resume-start {
 }
 
 $_TARGETNAME configure -event step-start {
-    # Note: As of Q2/2020, "step-start" event is a new feature in OpenOCD.
-    # A very recent version of OpenOCD is needed (upstream commit 25efc150 or newer).
     swerv_eh1_execute_fence
 }
 


### PR DESCRIPTION
This OpenOCD configuration change shall be used with SweRV EH1 1.8+.

Reason: Allow OpenOCD to access all memory, incl. core-local memories - ICCM, DCCM and PIC.