### PR TITLE
Add missing "expose_csrs" command to OpenOCD .cfg files

### DIFF
--- a/data/swervolf_nexys_debug.cfg
+++ b/data/swervolf_nexys_debug.cfg
@@ -26,6 +26,9 @@ riscv set_ir idcode 0x9
 riscv set_ir dmi 0x22
 riscv set_ir dtmcs 0x23
 
+# Expose custom SweRV's CSR dmst (csr1988)
+riscv expose_csrs 1988
+
 # Custom event hooks to flush SweRV ICACHE prior to step/resume
 proc swerv_eh1_execute_fence {} {
     # Execute fence + fence.i via "dmst" register

--- a/data/swervolf_sim.cfg
+++ b/data/swervolf_sim.cfg
@@ -14,6 +14,9 @@ target create $_TARGETNAME riscv -chain-position $_TARGETNAME
 # (prefer System Bus Access as there is no Debug Program Buffer in SweRV EH1)
 riscv set_prefer_sba on
 
+# Expose custom SweRV's CSR dmst (csr1988)
+riscv expose_csrs 1988
+
 # Custom event hooks to flush SweRV ICACHE prior to step/resume
 proc swerv_eh1_execute_fence {} {
     # Execute fence + fence.i via "dmst" register


### PR DESCRIPTION
This fixes OpenOCD configuration so that proper flush of ICACHE
automatically takes place on "step" or "resume" events.

The original pull request being fixed:
https://github.com/chipsalliance/Cores-SweRVolf/pull/13