### PR TITLE
hello_uart.S: Fix symbol label to point to string

### DIFF
--- a/sw/hello_uart.S
+++ b/sw/hello_uart.S
@@ -79,6 +79,7 @@ put_byte:
 
 	sb	t0, 0(a0)
 	ret
-str:
+
 	.section .data
+str:
 	.string "SweRV+FuseSoC rocks\n"


### PR DESCRIPTION
Tested on Nexys4 DDR.

We want to make sure that symbol `str` actually sits directly above
the `.string` directive. If the `str` label is defined directly before
the `.section .data` directive, then the symbol won't point to the
actual string bytes but somewhere above it, and will consequently
print garbage:

```
00010074 <_start>:
   10098:       00000597                auipc   a1,0x0
   1009c:       03258593                addi    a1,a1,50 # 100ca <str>
   100a0:       00058283                lb      t0,0(a1)
...

Disassembly of section .data:

000110ca <__DATA_BEGIN__>:
   110ca:       52657753                .4byte  0x52657753
   110ce:       2b56                    fld     fs6,336(sp)
...
```

Note the discrepancy between `100ca <str>` (the address the assembler
thinks its at) and the data actually sitting at `0x110ca`.

I think this is because if you look in the default linker script with
`riscv32-unknown-elf-ld -verbose ...`, the `.data` section is
preceeded by a page alignment:

```
* Adjust the address for the data segment.  We want to adjust up to
     the same address within the page on the next page up.  */
  . = DATA_SEGMENT_ALIGN (CONSTANT (MAXPAGESIZE), CONSTANT (COMMONPAGESIZE));
```

Hence the discrepancy of about `0x1000` (4kb). After this change, the
symbols correspond to eachother:

```
0010074 <_start>:
...
   10098:       00001597                auipc   a1,0x1
   1009c:       03258593                addi    a1,a1,50 # 110ca <__DATA_BEGIN__>
   100a0:       00058283                lb      t0,0(a1)
...

Disassembly of section .data:

000110ca <__DATA_BEGIN__>:
   110ca:       52657753                .4byte  0x52657753
   110ce:       2b56                    fld     fs6,336(sp)
...
```