### PR TITLE
Arty a7

### DIFF
--- a/data/swervolf_arty.xdc
+++ b/data/swervolf_arty.xdc
@@ -1,0 +1,47 @@
+create_clock -add -name sys_clk_pin -period 10.0 -waveform {0 5} [get_ports {clk}];
+create_clock -add -name tck_dmi -period 100.00 [get_pins tap/tap_dmi/TCK];
+create_clock -add -name tck_dtmcs -period 100.00 [get_pins tap/tap_dtmcs/TCK];
+create_clock -add -name tck_idcode -period 100.00 [get_pins tap/tap_idcode/DRCK];
+
+#FIXME: Improve this later but hopefully ok for now.
+#Since the JTAG clock is slow and bits 0 and 1 are properly synced, we can be a bit careless about the rest
+set_false_path -from  [get_cells -regexp {tap/dtmcs_r_reg\[([2-9]|[1-9][0-9])\]}]
+
+set_false_path -from  [get_cells ddr2/serial_tx_reg]
+
+set_property -dict { PACKAGE_PIN E3   IOSTANDARD LVCMOS33 } [get_ports { clk }];
+
+set_property -dict { PACKAGE_PIN C2   IOSTANDARD LVCMOS33 } [get_ports { rstn }];
+
+set_property -dict { PACKAGE_PIN D10  IOSTANDARD LVCMOS33 } [get_ports i_uart_rx]
+set_property -dict { PACKAGE_PIN A9   IOSTANDARD LVCMOS33 } [get_ports o_uart_tx]
+
+
+set_property -dict { PACKAGE_PIN K17   IOSTANDARD LVCMOS33 } [get_ports o_flash_mosi]; #IO_L1P_T0_D00_MOSI_14 Sch=qspi_dq[0]
+set_property -dict { PACKAGE_PIN K18   IOSTANDARD LVCMOS33 } [get_ports i_flash_miso]; #IO_L1N_T0_D01_DIN_14 Sch=qspi_dq[1]
+#set_property -dict { PACKAGE_PIN L14   IOSTANDARD LVCMOS33 } [get_ports { QSPI_DQ[2] }]; #IO_L2P_T0_D02_14 Sch=qspi_dq[2]
+#set_property -dict { PACKAGE_PIN M14   IOSTANDARD LVCMOS33 } [get_ports { QSPI_DQ[3] }]; #IO_L2N_T0_D03_14 Sch=qspi_dq[3]
+set_property -dict { PACKAGE_PIN L13   IOSTANDARD LVCMOS33 } [get_ports o_flash_cs_n];
+
+set_property -dict { PACKAGE_PIN A8    IOSTANDARD LVCMOS33 } [get_ports { i_sw[0] }]
+set_property -dict { PACKAGE_PIN C11   IOSTANDARD LVCMOS33 } [get_ports { i_sw[1] }]
+set_property -dict { PACKAGE_PIN C10   IOSTANDARD LVCMOS33 } [get_ports { i_sw[2] }]
+set_property -dict { PACKAGE_PIN A10   IOSTANDARD LVCMOS33 } [get_ports { i_sw[3] }]
+
+set_property -dict { PACKAGE_PIN H5    IOSTANDARD LVCMOS33 } [get_ports { o_led[0] }]
+set_property -dict { PACKAGE_PIN J5    IOSTANDARD LVCMOS33 } [get_ports { o_led[1] }]
+set_property -dict { PACKAGE_PIN T9    IOSTANDARD LVCMOS33 } [get_ports { o_led[2] }]
+set_property -dict { PACKAGE_PIN T10   IOSTANDARD LVCMOS33 } [get_ports { o_led[3] }]
+
+set_property -dict { PACKAGE_PIN E1    IOSTANDARD LVCMOS33 } [get_ports { o_led[4] }]
+set_property -dict { PACKAGE_PIN F6    IOSTANDARD LVCMOS33 } [get_ports { o_led[5] }]
+set_property -dict { PACKAGE_PIN G6    IOSTANDARD LVCMOS33 } [get_ports { o_led[6] }]
+set_property -dict { PACKAGE_PIN G4    IOSTANDARD LVCMOS33 } [get_ports { o_led[7] }]
+set_property -dict { PACKAGE_PIN J4    IOSTANDARD LVCMOS33 } [get_ports { o_led[8] }]
+set_property -dict { PACKAGE_PIN G3    IOSTANDARD LVCMOS33 } [get_ports { o_led[9] }]
+set_property -dict { PACKAGE_PIN H4    IOSTANDARD LVCMOS33 } [get_ports { o_led[10] }]
+set_property -dict { PACKAGE_PIN J2    IOSTANDARD LVCMOS33 } [get_ports { o_led[11] }]
+set_property -dict { PACKAGE_PIN J3    IOSTANDARD LVCMOS33 } [get_ports { o_led[12] }]
+set_property -dict { PACKAGE_PIN K2    IOSTANDARD LVCMOS33 } [get_ports { o_led[13] }]
+set_property -dict { PACKAGE_PIN H6    IOSTANDARD LVCMOS33 } [get_ports { o_led[14] }]
+set_property -dict { PACKAGE_PIN K1    IOSTANDARD LVCMOS33 } [get_ports { o_led[15] }]

--- a/data/swervolf_arty.xdc
+++ b/data/swervolf_arty.xdc
@@ -28,6 +28,11 @@ set_property -dict { PACKAGE_PIN C11   IOSTANDARD LVCMOS33 } [get_ports { i_sw[1
 set_property -dict { PACKAGE_PIN C10   IOSTANDARD LVCMOS33 } [get_ports { i_sw[2] }]
 set_property -dict { PACKAGE_PIN A10   IOSTANDARD LVCMOS33 } [get_ports { i_sw[3] }]
 
+set_property -dict { PACKAGE_PIN D9    IOSTANDARD LVCMOS33 } [get_ports { i_btn[0] }]
+set_property -dict { PACKAGE_PIN C9    IOSTANDARD LVCMOS33 } [get_ports { i_btn[1] }]
+set_property -dict { PACKAGE_PIN B9    IOSTANDARD LVCMOS33 } [get_ports { i_btn[2] }]
+set_property -dict { PACKAGE_PIN B8    IOSTANDARD LVCMOS33 } [get_ports { i_btn[3] }]
+
 set_property -dict { PACKAGE_PIN H5    IOSTANDARD LVCMOS33 } [get_ports { o_led[0] }]
 set_property -dict { PACKAGE_PIN J5    IOSTANDARD LVCMOS33 } [get_ports { o_led[1] }]
 set_property -dict { PACKAGE_PIN T9    IOSTANDARD LVCMOS33 } [get_ports { o_led[2] }]

--- a/data/swervolf_arty_debug.cfg
+++ b/data/swervolf_arty_debug.cfg
@@ -1,0 +1,58 @@
+# JTAG adapter configuration (on-board USB-JTAG adapter on Digilent Nexys A7)
+interface ftdi
+ftdi_device_desc "Digilent USB Device"
+ftdi_vid_pid 0x0403 0x6010
+ftdi_channel 0
+ftdi_layout_init 0x0088 0x008b
+reset_config none
+adapter_khz 10000
+
+transport select jtag
+
+# Configure JTAG chain and the target processor
+set _CHIPNAME riscv
+
+jtag newtap $_CHIPNAME cpu -irlen 6 -expected-id 0x03631093 -ignore-version
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME
+
+# No MMU on SweRV (do not attempt virt2phys address translation)
+riscv set_enable_virt2phys off
+
+# Configure memory access method
+# Utilize "abstract access" to allow to reach SweRV's ICCM, DCCM and PIC core-local memories.
+# Note: Requires SweRV EH1 1.8+ and recent riscv-openocd (commit 22d771d20 from Sep 14, 2020, or newer).
+riscv set_mem_access abstract
+
+# Alternate memory access configuration - via "system bus"
+# Caution: ICCM, DCCM and PIC cannot be reached.
+# riscv set_mem_access sysbus
+
+# Custom numbers for RISC-V Debug JTAG registers 
+# (needed due to JTAG tunneling via Xilinx BSCAN cell)
+riscv set_ir idcode 0x9
+riscv set_ir dmi 0x22
+riscv set_ir dtmcs 0x23
+
+# Expose custom SweRV's CSR dmst (csr1988)
+riscv expose_csrs 1988
+
+# Custom event hooks to flush SweRV ICACHE prior to step/resume
+proc swerv_eh1_execute_fence {} {
+    # Execute fence + fence.i via "dmst" register
+    reg csr1988 0x3
+}
+
+$_TARGETNAME configure -event resume-start {
+    swerv_eh1_execute_fence
+}
+
+$_TARGETNAME configure -event step-start {
+    swerv_eh1_execute_fence
+}
+
+# Conclude OpenOCD configuration
+init
+
+# Halt the target
+halt

--- a/data/swervolf_arty_program.cfg
+++ b/data/swervolf_arty_program.cfg
@@ -1,0 +1,21 @@
+interface ftdi
+ftdi_device_desc "Digilent USB Device"
+ftdi_vid_pid 0x0403 0x6010
+ftdi_channel 0
+ftdi_layout_init 0x0088 0x008b
+reset_config none
+adapter_khz 10000
+
+transport select jtag
+
+source [find cpld/xilinx-xc7.cfg]
+
+if { [info exists BITFILE] } {
+	set _BITFILE $BITFILE
+} else {
+	set _BITFILE build/swervolf_0/nexys_a7-vivado/swervolf_0.bit
+}
+
+init
+pld load 0 $_BITFILE
+shutdown

--- a/data/swervolf_arty_write_flash.cfg
+++ b/data/swervolf_arty_write_flash.cfg
@@ -1,0 +1,24 @@
+interface ftdi
+ftdi_device_desc "Digilent USB Device"
+ftdi_vid_pid 0x0403 0x6010
+ftdi_channel 0
+ftdi_layout_init 0x0088 0x008b
+reset_config none
+adapter_khz 10000
+
+transport select jtag
+
+source [find cpld/xilinx-xc7.cfg]
+source [find cpld/jtagspi.cfg]
+
+if { [info exists BINFILE] } {
+	set _BINFILE $BINFILE
+} else {
+	set _BINFILE boot.bin
+}
+
+init
+jtagspi_init 0 bscan_spi_xc7a35t.bit
+jtagspi_program $_BINFILE 0x0
+shutdown
+

--- a/rtl/clk_gen_arty.v
+++ b/rtl/clk_gen_arty.v
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2019 Western Digital Corporation or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//********************************************************************************
+// $Id$
+//
+// Function: SweRVolf Basys3 clock generation
+// Comments:
+//
+//********************************************************************************
+
+module clk_gen_arty
+  (input  wire i_clk,
+   input  wire     i_rst,
+   output wire     o_clk_core,
+   output reg o_rst_core);
+
+   wire   clkfb;
+   wire   locked;
+   reg 	  locked_r;
+
+   PLLE2_BASE
+     #(.BANDWIDTH("OPTIMIZED"),
+       .CLKFBOUT_MULT(16),
+       .CLKIN1_PERIOD(10.0),   // 100 MHz
+       .CLKOUT0_DIVIDE(64),    //  25 MHz
+       .DIVCLK_DIVIDE(1),
+       .STARTUP_WAIT("FALSE"))
+   PLLE2_BASE_inst
+     (.CLKOUT0(o_clk_core),
+      .CLKOUT1(),
+      .CLKOUT2(),
+      .CLKOUT3(),
+      .CLKOUT4(),
+      .CLKOUT5(),
+      .CLKFBOUT(clkfb),
+      .LOCKED(locked),
+      .CLKIN1(i_clk),
+      .PWRDWN(1'b0),
+      .RST(i_rst),
+      .CLKFBIN(clkfb));
+
+   always @(posedge o_clk_core) begin
+      locked_r <= locked;
+      o_rst_core <= !locked_r;
+   end
+
+endmodule

--- a/rtl/swervolf_arty.v
+++ b/rtl/swervolf_arty.v
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2019 Western Digital Corporation or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//********************************************************************************
+// $Id$
+//
+// Function: SweRVolf toplevel for Arty A7 board
+// Comments:
+//
+//********************************************************************************
+
+`default_nettype none
+module swervolf_arty_a7
+  #(parameter bootrom_file = "bootloader.vh")
+   (input wire 	       clk,
+    input wire 	       rstn,
+    output wire [12:0] ddram_a,
+    output wire [2:0]  ddram_ba,
+    output wire        ddram_ras_n,
+    output wire        ddram_cas_n,
+    output wire        ddram_we_n,
+    output wire        ddram_cs_n,
+    output wire [1:0]  ddram_dm,
+    inout wire [15:0]  ddram_dq,
+    inout wire [1:0]  ddram_dqs_p,
+    inout wire [1:0]  ddram_dqs_n,
+    output wire        ddram_clk_p,
+    output wire        ddram_clk_n,
+    output wire        ddram_cke,
+    output wire        ddram_odt,
+    output wire        o_flash_cs_n,
+    output wire        o_flash_mosi,
+    input wire 	       i_flash_miso,
+    input wire 	       i_uart_rx,
+    output wire        o_uart_tx,
+    input wire  [3:0]  i_sw,
+    output reg [15:0]  o_led);
+
+   wire [63:0] 	       gpio_out;
+   reg [15:0] 	       led_int_r;
+
+   reg [3:0] 	       sw_r;
+   reg [15:0] 	       sw_2r;
+
+   wire 	       cpu_tx,litedram_tx;
+
+   wire 	       litedram_init_done;
+   wire 	       litedram_init_error;
+
+   localparam RAM_SIZE     = 32'h10000;
+
+   wire 	 clk_core;
+   wire 	 rst_core;
+   wire 	 user_clk;
+   wire 	 user_rst;
+
+   clk_gen_arty
+   clk_gen
+     (.i_clk (user_clk),
+      .i_rst (user_rst),
+      .o_clk_core (clk_core),
+      .o_rst_core (rst_core));
+
+   AXI_BUS #(32, 64, 6, 1) mem();
+   AXI_BUS #(32, 64, 6, 1) cpu();
+
+   assign cpu.aw_atop = 6'd0;
+   assign cpu.aw_user = 1'b0;
+   assign cpu.ar_user = 1'b0;
+   assign cpu.w_user = 1'b0;
+   assign cpu.b_user = 1'b0;
+   assign cpu.r_user = 1'b0;
+   assign mem.b_user = 1'b0;
+   assign mem.r_user = 1'b0;
+
+   axi_cdc_intf
+     #(.AXI_USER_WIDTH (1),
+       .AXI_ADDR_WIDTH (32),
+       .AXI_DATA_WIDTH (64),
+       .AXI_ID_WIDTH   (6))
+   cdc
+     (
+      .src_clk_i  (clk_core),
+      .src_rst_ni (~rst_core),
+      .src        (cpu),
+      .dst_clk_i  (user_clk),
+      .dst_rst_ni (~user_rst),
+      .dst        (mem));
+
+   litedram_top
+     #(.ID_WIDTH (6))
+   ddr2
+     (.serial_tx   (litedram_tx),
+      .serial_rx   (i_uart_rx),
+      .clk100      (clk),
+      .rst_n       (rstn),
+      .pll_locked  (),
+      .user_clk    (user_clk),
+      .user_rst    (user_rst),
+      .ddram_a     (ddram_a),
+      .ddram_ba    (ddram_ba),
+      .ddram_ras_n (ddram_ras_n),
+      .ddram_cas_n (ddram_cas_n),
+      .ddram_we_n  (ddram_we_n),
+      .ddram_cs_n  (ddram_cs_n),
+      .ddram_dm    (ddram_dm   ),
+      .ddram_dq    (ddram_dq   ),
+      .ddram_dqs_p (ddram_dqs_p),
+      .ddram_dqs_n (ddram_dqs_n),
+      .ddram_clk_p (ddram_clk_p),
+      .ddram_clk_n (ddram_clk_n),
+      .ddram_cke   (ddram_cke  ),
+      .ddram_odt   (ddram_odt  ),
+      .init_done  (litedram_init_done),
+      .init_error (litedram_init_error),
+      .i_awid    (mem.aw_id   ),
+      .i_awaddr  (mem.aw_addr[26:0] ),
+      .i_awlen   (mem.aw_len  ),
+      .i_awsize  ({1'b0,mem.aw_size} ),
+      .i_awburst (mem.aw_burst),
+      .i_awvalid (mem.aw_valid),
+      .o_awready (mem.aw_ready),
+      .i_arid    (mem.ar_id   ),
+      .i_araddr  (mem.ar_addr[26:0] ),
+      .i_arlen   (mem.ar_len  ),
+      .i_arsize  ({1'b0,mem.ar_size} ),
+      .i_arburst (mem.ar_burst),
+      .i_arvalid (mem.ar_valid),
+      .o_arready (mem.ar_ready),
+      .i_wdata   (mem.w_data  ),
+      .i_wstrb   (mem.w_strb  ),
+      .i_wlast   (mem.w_last  ),
+      .i_wvalid  (mem.w_valid ),
+      .o_wready  (mem.w_ready ),
+      .o_bid     (mem.b_id    ),
+      .o_bresp   (mem.b_resp  ),
+      .o_bvalid  (mem.b_valid ),
+      .i_bready  (mem.b_ready ),
+      .o_rid     (mem.r_id    ),
+      .o_rdata   (mem.r_data  ),
+      .o_rresp   (mem.r_resp  ),
+      .o_rlast   (mem.r_last  ),
+      .o_rvalid  (mem.r_valid ),
+      .i_rready  (mem.r_ready ));
+
+   wire        dmi_reg_en;
+   wire [6:0]  dmi_reg_addr;
+   wire        dmi_reg_wr_en;
+   wire [31:0] dmi_reg_wdata;
+   wire [31:0] dmi_reg_rdata;
+   wire        dmi_hard_reset;
+
+   wire        flash_sclk;
+
+   STARTUPE2 STARTUPE2
+     (
+      .CFGCLK    (),
+      .CFGMCLK   (),
+      .EOS       (),
+      .PREQ      (),
+      .CLK       (1'b0),
+      .GSR       (1'b0),
+      .GTS       (1'b0),
+      .KEYCLEARB (1'b1),
+      .PACK      (1'b0),
+      .USRCCLKO  (flash_sclk),
+      .USRCCLKTS (1'b0),
+      .USRDONEO  (1'b1),
+      .USRDONETS (1'b0));
+
+   bscan_tap tap
+     (.clk            (clk_core),
+      .rst            (rst_core),
+      .jtag_id        (31'd0),
+      .dmi_reg_wdata  (dmi_reg_wdata),
+      .dmi_reg_addr   (dmi_reg_addr),
+      .dmi_reg_wr_en  (dmi_reg_wr_en),
+      .dmi_reg_en     (dmi_reg_en),
+      .dmi_reg_rdata  (dmi_reg_rdata),
+      .dmi_hard_reset (dmi_hard_reset),
+      .rd_status      (2'd0),
+      .idle           (3'd0),
+      .dmi_stat       (2'd0),
+      .version        (4'd1));
+
+   swervolf_core
+     #(.bootrom_file (bootrom_file),
+       .clk_freq_hz  (32'd25_000_000))
+   swervolf
+     (.clk  (clk_core),
+      .rstn (~rst_core),
+      .dmi_reg_rdata  (dmi_reg_rdata),
+      .dmi_reg_wdata  (dmi_reg_wdata),
+      .dmi_reg_addr   (dmi_reg_addr ),
+      .dmi_reg_en     (dmi_reg_en   ),
+      .dmi_reg_wr_en  (dmi_reg_wr_en),
+      .dmi_hard_reset (dmi_hard_reset),
+      .o_flash_sclk   (flash_sclk),
+      .o_flash_cs_n   (o_flash_cs_n),
+      .o_flash_mosi   (o_flash_mosi),
+      .i_flash_miso   (i_flash_miso),
+      .i_uart_rx      (i_uart_rx),
+      .o_uart_tx      (cpu_tx),
+      .o_ram_awid     (cpu.aw_id),
+      .o_ram_awaddr   (cpu.aw_addr),
+      .o_ram_awlen    (cpu.aw_len),
+      .o_ram_awsize   (cpu.aw_size),
+      .o_ram_awburst  (cpu.aw_burst),
+      .o_ram_awlock   (cpu.aw_lock),
+      .o_ram_awcache  (cpu.aw_cache),
+      .o_ram_awprot   (cpu.aw_prot),
+      .o_ram_awregion (cpu.aw_region),
+      .o_ram_awqos    (cpu.aw_qos),
+      .o_ram_awvalid  (cpu.aw_valid),
+      .i_ram_awready  (cpu.aw_ready),
+      .o_ram_arid     (cpu.ar_id),
+      .o_ram_araddr   (cpu.ar_addr),
+      .o_ram_arlen    (cpu.ar_len),
+      .o_ram_arsize   (cpu.ar_size),
+      .o_ram_arburst  (cpu.ar_burst),
+      .o_ram_arlock   (cpu.ar_lock),
+      .o_ram_arcache  (cpu.ar_cache),
+      .o_ram_arprot   (cpu.ar_prot),
+      .o_ram_arregion (cpu.ar_region),
+      .o_ram_arqos    (cpu.ar_qos),
+      .o_ram_arvalid  (cpu.ar_valid),
+      .i_ram_arready  (cpu.ar_ready),
+      .o_ram_wdata    (cpu.w_data),
+      .o_ram_wstrb    (cpu.w_strb),
+      .o_ram_wlast    (cpu.w_last),
+      .o_ram_wvalid   (cpu.w_valid),
+      .i_ram_wready   (cpu.w_ready),
+      .i_ram_bid      (cpu.b_id),
+      .i_ram_bresp    (cpu.b_resp),
+      .i_ram_bvalid   (cpu.b_valid),
+      .o_ram_bready   (cpu.b_ready),
+      .i_ram_rid      (cpu.r_id),
+      .i_ram_rdata    (cpu.r_data),
+      .i_ram_rresp    (cpu.r_resp),
+      .i_ram_rlast    (cpu.r_last),
+      .i_ram_rvalid   (cpu.r_valid),
+      .o_ram_rready   (cpu.r_ready),
+      .i_ram_init_done  (litedram_init_done),
+      .i_ram_init_error (litedram_init_error),
+      .i_gpio           ({32'd0,sw_2r,16'd0}),
+      .o_gpio           (gpio_out));
+
+   always @(posedge clk_core) begin
+      o_led <= led_int_r;
+      led_int_r <= gpio_out[15:0];
+      sw_r <= i_sw;
+      sw_2r[3:0] <= sw_r;
+   end
+
+   assign o_uart_tx = sw_2r[0] ? litedram_tx : cpu_tx;
+
+endmodule

--- a/rtl/swervolf_arty.v
+++ b/rtl/swervolf_arty.v
@@ -46,6 +46,7 @@ module swervolf_arty_a7
     input wire 	       i_uart_rx,
     output wire        o_uart_tx,
     input wire  [3:0]  i_sw,
+    input wire  [3:0]  i_btn,
     output reg [15:0]  o_led);
 
    wire [63:0] 	       gpio_out;
@@ -53,6 +54,7 @@ module swervolf_arty_a7
 
    reg [3:0] 	       sw_r;
    reg [15:0] 	       sw_2r;
+   reg [3:0] 	       btn_r;
 
    wire 	       cpu_tx,litedram_tx;
 
@@ -261,7 +263,9 @@ module swervolf_arty_a7
       o_led <= led_int_r;
       led_int_r <= gpio_out[15:0];
       sw_r <= i_sw;
+      btn_r <= i_btn;
       sw_2r[3:0] <= sw_r;
+      sw_2r[7:4] <= btn_r;
    end
 
    assign o_uart_tx = sw_2r[0] ? litedram_tx : cpu_tx;

--- a/swervolf.core
+++ b/swervolf.core
@@ -59,6 +59,15 @@ filesets:
       - rtl/swervolf_nexys.v    : {file_type : systemVerilogSource}
     depend : [":swervolf:litedram"]
 
+  arty_a7_files:
+    files :
+      - data/vivado_waiver.tcl : {file_type : tclSource}
+      - data/swervolf_arty.xdc : {file_type : xdc}
+      - rtl/clk_gen_arty.v : {file_type : verilogSource}
+      - rtl/bscan_tap.sv    : {file_type : systemVerilogSource}
+      - rtl/swervolf_arty.v    : {file_type : systemVerilogSource}
+    depend : [":swervolf:litedram"]
+
   basys3_files:
     files :
       - data/vivado_waiver.tcl : {file_type : tclSource}
@@ -165,6 +174,20 @@ targets:
     tools:
       vivado: {part : xc7a100tcsg324-1}
     toplevel : swervolf_nexys_a7
+
+  arty_a7:
+    default_tool : vivado
+    description : FPGA image with SweRV EL2 for the Digilent Arty A7 FPGA board
+    filesets :
+      - bootrom
+      - el2
+      - core
+      - arty_a7_files
+    generate : [intercon, swerv_el2_nexys_a7_config, version, wb_intercon]
+    parameters : [bootrom_file]
+    tools:
+      vivado: {part : xc7a35tcsg324-1}
+    toplevel : swervolf_arty_a7
 
 generate:
   wb_intercon:

--- a/swervolf.core
+++ b/swervolf.core
@@ -183,7 +183,7 @@ targets:
       - el2
       - core
       - arty_a7_files
-    generate : [intercon, swerv_el2_nexys_a7_config, version, wb_intercon]
+    generate : [intercon, swerv_el2_arty_a7_config, version, wb_intercon]
     parameters : [bootrom_file]
     tools:
       vivado: {part : xc7a35tcsg324-1}
@@ -255,6 +255,28 @@ generate:
         - -set=iccm_enable=0
         - -set=icache_enable=0
         - -set=dccm_enable=0
+
+  swerv_el2_arty_a7_config:
+    generator: swerv_el2_config
+    position : first
+    parameters:
+      args :
+        - -unset=assert_on
+        - -set=reset_vec=0x80000000
+        - -set=ret_stack_size=2
+        - -set=btb_enable=0
+        - -set=btb_size=8
+        - -set=bht_size=32
+        - -set=dccm_size=16
+        - -set=dccm_num_banks=2
+        - -set=iccm_enable=0
+        - -set=icache_enable=0
+        - -set=dccm_enable=0
+        - -set=dma_buf_depth=2
+        - -set=div_bit=1
+        - -set=pic_total_int=2
+
+# - -target=default_ahb
 
   version:
     generator: gitversion


### PR DESCRIPTION
This produces a bitfile that fits into the FPGA of a Digilent Arty A7 35 board including the DRAM core.
Some resources needed to be reduced compared to the basys version.