### PR TITLE
Fix off by one error in SPI bootloader

### DIFF
--- a/sw/spi_uimage_loader.S
+++ b/sw/spi_uimage_loader.S
@@ -146,7 +146,7 @@ copy_to_ram:
 	addi	s4, s4, 4
 
 	/* Check if file is completely copied */
-	bge	s0, s4, copy_to_ram
+	bgt	s0, s4, copy_to_ram
 
 	/* Jump to entry point */
 goto_reset:


### PR DESCRIPTION
s4 contains the number of bytes copied so far, and s0 contains the number of bytes to copy. When these are equal, we have copied everything and we shouldn't run one more iteration.

If the flash image is being loaded so it lines up with the end of system memory, this causes a write past the end of system memory. I found this while adapting the bootloader to my own hardware.